### PR TITLE
fix: Incrementing Duration #21

### DIFF
--- a/src/timecard/interface/editview.py
+++ b/src/timecard/interface/editview.py
@@ -119,7 +119,31 @@ class EditView:
         cls.refresh()
 
     @classmethod
+    def normalize(cls):
+        hour = cls.spn_hour.value()
+        min = cls.spn_min.value()
+        sec = cls.spn_sec.value()
+
+        print(hour, min, sec)
+
+        if sec > 60:
+            min += sec // 60
+            sec %= 60
+        if min > 60:
+            hour += min // 60
+            min %= 60
+
+        print(hour, min, sec)
+
+        cls.spn_hour.setValue(hour)
+        cls.spn_min.setValue(min)
+        cls.spn_sec.setValue(sec)
+
+    @classmethod
     def edited(cls):
+        # Normalize times
+        cls.normalize()
+        # Change interface to allow saving or reverting.
         cls.btn_done.setEnabled(False)
         cls.btn_revert.setEnabled(True)
         cls.btn_save.setEnabled(True)


### PR DESCRIPTION
When seconds or minutes are added or removed via the Edit View,
minutes and hours should be adjusted accordingly. That is, we should
never allow 62 seconds or -5 minutes or any similar nonsense to be
displayed and stored as such.